### PR TITLE
Change default build configuration to Debug

### DIFF
--- a/flutter/mosaicizer/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutter/mosaicizer/ios/Runner.xcodeproj/project.pbxproj
@@ -738,7 +738,7 @@
 				331C808A294A63A400263BE5 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
@@ -748,7 +748,7 @@
 				249021D3217E4FDB00AE95B9 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */ = {
 			isa = XCConfigurationList;
@@ -758,7 +758,7 @@
 				249021D4217E4FDB00AE95B9 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
In Runner.xcodeproj, the default configuration for building the project has been modified. It was initially set as Release, but has now been changed to Debug. This adjustment affects the PBXProject "Runner", its XBConfigurationList, and the PBXNativeTarget "Runner" settings.