### PR TITLE
Move hideLoadingOverlay function call

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -214,7 +214,6 @@ function handleSliderInput() {
   document.getElementById("pixelSizeValue").textContent = this.value;
   App.currentSliderValue = parseInt(App.sliderElement.value, 10) - 1;
   redrawFace();
-  hideLoadingOverlay();
   App.sliderElement.disabled = true;
   console.log(App.preprocessedFaces);
   setTimeout(() => {
@@ -573,6 +572,7 @@ function redrawFace() {
         App.currentFace.click();
       }
     }
+    hideLoadingOverlay();
   }, 50);
 }
 


### PR DESCRIPTION
The hideLoadingOverlay() function has been moved from the document ready event to a setTimeout callback to ensure that it is called after UI updates have been completed. This helps prevent triggering the function prematurely and will improve the user-interface behavior.